### PR TITLE
Add unique name for link for accessibility

### DIFF
--- a/main.css
+++ b/main.css
@@ -42,3 +42,13 @@ input[type=checkbox].add-to-calendar-checkbox {
 .icon-google:before {
   background-position: -52px 0;
 }
+.screen-readers {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/ouical.js
+++ b/ouical.js
@@ -27,7 +27,7 @@
         '&sprop=&sprop=name:'
       ].join(''));
       return '<a class="icon-google" target="_blank" href="' +
-        href + '">Google Calendar</a>';
+        href + '">Google Calendar' + event.uniqueInfo + '</a>';
     },
 
     yahoo: function(event) {
@@ -60,7 +60,7 @@
       ].join(''));
 
       return '<a class="icon-yahoo" target="_blank" href="' +
-        href + '">Yahoo! Calendar</a>';
+        href + '">Yahoo! Calendar' + event.uniqueInfo + '</a>';
     },
 
     ics: function(event, eClass, calendarName) {
@@ -82,7 +82,7 @@
           'END:VCALENDAR'].join('\n'));
 
       return '<a class="' + eClass + '" target="_blank" href="' +
-        href + '">' + calendarName + ' Calendar</a>';
+        href + '">' + calendarName + ' Calendar' + event.uniqueInfo + '</a>';
     },
 
     ical: function(event) {
@@ -95,6 +95,7 @@
   };
 
   var generateCalendars = function(event) {
+    event.uniqueInfo = '<span class="screen-readers">for ' + event.title + ' on ' + event.start +'</span>';
     return {
       google: calendarGenerators.google(event),
       yahoo: calendarGenerators.yahoo(event),


### PR DESCRIPTION
In cases where there are more than one Add to Calendar button per page, the various links need to be unique in order for users of assistive technology to be able to differentiate them.

Accessibility-wise, a link that simply says 'Google Calendar' isn't descriptive enough for someone using a screen reader to be able to use it to navigate successfullly.

This is my first time contributing to an open source thing, so please let me know if I'm doing this all wrong.